### PR TITLE
Fix build issue on Ubuntu

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -87,5 +87,5 @@ ifeq ($(shell mysql_config --version >/dev/null 2>&1 && echo ok),ok)
     mysqlLibs = $(shell mysql_config --libs)
 endif
 
-dblibs = ${tokyoCabinetLib} ${kyotoTycoonLib} ${mysqlLibs} -lz
+dblibs = ${tokyoCabinetLib} ${kyotoTycoonLib} ${mysqlLibs} -lz -lm
 


### PR DESCRIPTION
-lm is needed for linking to any of the hash functions, added it to include.mk
