### PR TITLE
Fixed placement of -lm option to link against the math library. Static l...

### DIFF
--- a/C/Makefile
+++ b/C/Makefile
@@ -20,12 +20,12 @@ clean :
 
 ${binPath}/sonLibTests : ${libTests} ${libInternalHeaders} ${libPath}/sonLib.a ${libPath}/cuTest.a tests/allTests.c
 	@mkdir -p $(dir $@)
-	${cxx} ${cflags} -I inc -I ${libPath} -o $@.tmp tests/allTests.c ${libTests} ${libPath}/sonLib.a ${libPath}/cuTest.a ${dblibs} ${mysqlLibs}
+	${cxx} ${cflags} -I inc -I ${libPath} -o $@.tmp tests/allTests.c ${libTests} ${libPath}/sonLib.a ${libPath}/cuTest.a ${dblibs} ${mysqlLibs} -lm
 	mv $@.tmp $@
 
 ${binPath}/sonLib_kvDatabaseTest : ${libTests} ${libInternalHeaders} ${libPath}/sonLib.a ${libPath}/cuTest.a tests/kvDatabaseTest.c tests/kvDatabaseTestCommon.c
 	@mkdir -p $(dir $@)
-	${cxx} ${cflags} -I inc -I ${libPath} -I tests -o $@.tmp tests/kvDatabaseTest.c tests/kvDatabaseTestCommon.c ${libPath}/sonLib.a ${libPath}/cuTest.a ${dblibs} ${mysqlLibs}
+	${cxx} ${cflags} -I inc -I ${libPath} -I tests -o $@.tmp tests/kvDatabaseTest.c tests/kvDatabaseTestCommon.c ${libPath}/sonLib.a ${libPath}/cuTest.a ${dblibs} ${mysqlLibs} -lm
 	mv $@.tmp $@
 
 ${binPath}/sonLib_cigarTest : tests/cigarsTest.c ${libTests} ${libInternalHeaders} ${libPath}/sonLib.a 
@@ -40,7 +40,7 @@ ${binPath}/sonLib_fastaCTest : tests/fastaCTest.c ${libTests} ${libInternalHeade
 
 ${binPath}/kt_connect_test : tests/kt_connect_test.cpp ${libTests} ${libInternalHeaders} ${libPath}/sonLib.a
 	@mkdir -p $(dir $@)
-	${cpp} ${cppflags} -I inc -I ${libPath}/ -o $@.tmp tests/kt_connect_test.cpp ${libPath}/sonLib.a -lm ${dblibs}
+	${cpp} ${cppflags} -I inc -I ${libPath}/ -o $@.tmp tests/kt_connect_test.cpp ${libPath}/sonLib.a ${dblibs} -lm
 	mv $@.tmp $@
 
 ${libPath}/%.h: inc/%.h

--- a/include.mk
+++ b/include.mk
@@ -15,27 +15,31 @@ else
 # -Wno-unused-result
 endif
 
+# Compiler flags.
+# DO NOT put static library -l options here. Those must be specified *after*
+# linker input files. See <http://stackoverflow.com/a/8266512/402891>.
+
 #Release compiler flags
-cflags_opt = -O3 -g -Wall --pedantic -funroll-loops -lm -DNDEBUG
+cflags_opt = -O3 -g -Wall --pedantic -funroll-loops -DNDEBUG
 #-fopenmp
-cppflags_opt = -O3 -g -Wall -funroll-loops -lm -DNDEBUG
+cppflags_opt = -O3 -g -Wall -funroll-loops -DNDEBUG
 
 #Debug flags (slow)
-cflags_dbg = -Wall -Werror --pedantic -g -fno-inline -lm
-cppflags_dbg = -Wall -g -O0 -fno-inline  -lm
+cflags_dbg = -Wall -Werror --pedantic -g -fno-inline
+cppflags_dbg = -Wall -g -O0 -fno-inline 
 
 #Ultra Debug flags (really slow)
-cflags_ultraDbg = -Wall -Werror --pedantic -g -fno-inline -lm
+cflags_ultraDbg = -Wall -Werror --pedantic -g -fno-inline
 
 #Profile flags
-cflags_prof = -Wall -Werror --pedantic -pg -O3 -g -lm
+cflags_prof = -Wall -Werror --pedantic -pg -O3 -g
 
 #for cpp code: don't use pedantic, or Werror
 cppflags = ${cppflags_opt} 
 
 #Flags to use
-cflags = ${cflags_opt}  
- 
+cflags = ${cflags_opt}
+
 # location of Tokyo cabinet
 ifndef tokyoCabinetLib
 ifneq ($(wildcard /hive/groups/recon/local/include/tcbdb.h),)


### PR DESCRIPTION
...ib -l options can't go in cflags, since they're specified before input files, and static libs are only checked for undefined references that the linker already knows need defining.

Fixes the build on Ubuntu 12.04.

Now in its own branch just for merging upstream, so it doesn't have to come with all my setup.py changes.
