### PR TITLE
Smarter handling of edge cases in getTempDirectory

### DIFF
--- a/bioio.py
+++ b/bioio.py
@@ -445,18 +445,30 @@ def getTempFile(suffix="", rootDir=None):
 
 def getTempDirectory(rootDir=None):
     """
-    returns a temporary directory that must be manually deleted
+    returns a temporary directory that must be manually deleted. rootDir will be
+    created if it does not exist.
     """
     if rootDir is None:
         return tempfile.mkdtemp()
     else:
+        if not os.path.exists(rootDir):
+            try:
+                os.makedirs(rootDir)
+            except OSError:
+                # Maybe it got created between the test and the makedirs call?
+                pass
+            
         while True:
-            rootDir = os.path.join(rootDir, "tmp_" + getRandomAlphaNumericString())
-            if not os.path.exists(rootDir):
+            # Keep trying names until we find one that doesn't exist. If one
+            # does exist, don't nest inside it, because someone else may be
+            # using it for something.
+            tmpDir = os.path.join(rootDir, "tmp_" + getRandomAlphaNumericString())
+            if not os.path.exists(tmpDir):
                 break
-        os.mkdir(rootDir)
-        os.chmod(rootDir, 0777) #Ensure everyone has access to the file.
-        return rootDir
+                
+        os.mkdir(tmpDir)
+        os.chmod(tmpDir, 0777) #Ensure everyone has access to the file.
+        return tmpDir
 
 class TempFileTree:
     """A hierarchical tree structure for storing directories of files/dirs/


### PR DESCRIPTION
Don't nest inside colliding directories, and create the root temp directory if it doesn't exist.