### PR TITLE
PWD is only set in shell sessions, use os.getcwd() instead

### DIFF
--- a/bioio.py
+++ b/bioio.py
@@ -249,7 +249,7 @@ def getTotalMemoryUsage():
 def absSymPath(path):
     """like os.path.abspath except it doesn't dereference symlinks
     """
-    curr_path = os.environ['PWD']
+    curr_path = os.getcwd()
     return os.path.normpath(os.path.join(curr_path, path))
 
 #########################################################


### PR DESCRIPTION
This fixes jobTree failing when run from an IDE such as PyCharm