### PR TITLE
found bug in fastaRead where lack of trailing newline leads to truncation

### DIFF
--- a/bioio.py
+++ b/bioio.py
@@ -698,7 +698,7 @@ def _getFileHandle(fileHandleOrFile, mode="r"):
     else:
         return fileHandleOrFile
 
-def fastaIanRead(fileHandleOrFile):
+def fastaRead(fileHandleOrFile):
     """iteratively yields a sequence for each '>' it encounters, ignores '#' lines
     """
     fileHandle = _getFileHandle(fileHandleOrFile)

--- a/bioio.py
+++ b/bioio.py
@@ -20,6 +20,7 @@ from tree import BinaryTree
 from misc import close
 import subprocess
 import array
+import string
 import xml.etree.cElementTree as ET
 from xml.dom import minidom  # For making stuff pretty
 
@@ -717,7 +718,8 @@ def fastaIanRead(fileHandleOrFile):
             try:
                 assert all(x in valid_chars for x in seq)
             except AssertionError:
-                raise RuntimeError("Invalid FASTA character, ASCII code = \'%d\', found in input sequence %s" % (ord(i), name))
+                bad_chars = {x for x in seq if x not in valid_chars}
+                raise RuntimeError("Invalid FASTA character(s) see in fasta sequence: {}".format(bad_chars))
             yield name, seq.tostring()
         else:
             line = fileHandle.readline()

--- a/bioio.py
+++ b/bioio.py
@@ -697,24 +697,27 @@ def _getFileHandle(fileHandleOrFile, mode="r"):
     else:
         return fileHandleOrFile
 
-def fastaRead(fileHandleOrFile):
-    """iteratively a sequence for each '>' it encounters, ignores '#' lines
+def fastaIanRead(fileHandleOrFile):
+    """iteratively yields a sequence for each '>' it encounters, ignores '#' lines
     """
     fileHandle = _getFileHandle(fileHandleOrFile)
     line = fileHandle.readline()
+    chars_to_remove = "\n "
+    valid_chars = {x for x in string.ascii_letters + "-"}
     while line != '':
         if line[0] == '>':
             name = line[1:-1]
             line = fileHandle.readline()
             seq = array.array('c')
             while line != '' and line[0] != '>':
+                line = line.translate(None, chars_to_remove)
                 if line[0] != '#':
-                    seq.extend([ i for i in line[:-1] if not i.isspace() ]) #The white-space check is to remove any annoying trailing characters.
+                    seq.extend(line)
                 line = fileHandle.readline()
-            for i in seq:
-                #For safety and sanity I only allows roman alphabet characters in fasta sequences.
-                if not ((i >= 'A' and i <= 'Z') or (i >= 'a' and i <= 'z') or i == '-'):
-                    raise RuntimeError("Invalid FASTA character, ASCII code = \'%d\', found in input sequence %s" % (ord(i), name))
+            try:
+                assert all(x in valid_chars for x in seq)
+            except AssertionError:
+                raise RuntimeError("Invalid FASTA character, ASCII code = \'%d\', found in input sequence %s" % (ord(i), name))
             yield name, seq.tostring()
         else:
             line = fileHandle.readline()


### PR DESCRIPTION
Here is the original fastaReader trying to read a short fasta file with and without a trailing newline:

>>> list(fastaRead("very_short_unmasked.fa"))
[('Notch2NL-A_0', 'AGGTCCTAAACCCTTGACTCATA'), ('Notch2NL-B_0', 'AGGTCCTAGACCCTTGACTCAT')] #truncated
>>> list(fastaRead("very_short_unmasked.fa"))
[('Notch2NL-A_0', 'AGGTCCTAAACCCTTGACTCATA'), ('Notch2NL-B_0', 'AGGTCCTAGACCCTTGACTCATA')] #not truncated

I also decided to optimize this function a bit since I use it so much.
Timit comparison of the two versions:

>>> def IanWrapper():
...     q = list(fastaIanRead("data/kmer_model_data/notch2nl_unmasked_hg38.fa"))
...
>>>
>>> def SonLibWrapper():
...     q = list(fastaRead("data/kmer_model_data/notch2nl_unmasked_hg38.fa"))
...
>>>
>>> import array, string
>>> from sonLib.bioio import fastaRead, _getFileHandle
>>> from src.ian_fasta_read import fastaIanRead
>>> from timeit import timeit
>>>
>>> timeit(IanWrapper, number=10)
0.7704260349273682
>>> timeit(SonLibWrapper, number=10)
1.2819149494171143
>>>
>>>
