### PR TITLE
slower hashtable expansion

### DIFF
--- a/C/impl/hashTableC.c
+++ b/C/impl/hashTableC.c
@@ -15,7 +15,7 @@
  http://br.endernet.org/~akrowne/
  http://planetmath.org/encyclopedia/GoodHashTablePrimes.html
  */
-static const uint64_t primes[] = { 53, 97, 193, 389, 769, 1543, 3079, 6151,
+static const uint64_t primes[] = { 2, 11, 23, 53, 97, 193, 389, 769, 1543, 3079, 6151,
         12289, 24593, 49157, 98317, 196613, 393241, 786433, 1572869, 3145739,
         6291469, 12582917, 25165843, 50331653, 100663319, 201326611, 402653189,
         805306457, 1610612741 };


### PR DESCRIPTION
Cactus can make [lots of hash tables](https://github.com/ComparativeGenomicsToolkit/pinchesAndCacti/blob/master/inc/stCactusGraphs.h#L40-L48).  They start off with [53 elements](https://github.com/benedictpaten/sonLib/blob/dc477fe27f7524c10c40d2a8e713624f1b30baa6/C/impl/hashTableC.c#L18) upon creation.  This can take up [a lot of space](https://github.com/vgteam/vg/issues/2265).   This PR makes the table size ramp up a bit more slowly.   It cuts memory usage by about half in the case I'm looking at without affecting speed.